### PR TITLE
Update to Silk.NET 2.22.0

### DIFF
--- a/VMASharp/DedicatedAllocation.cs
+++ b/VMASharp/DedicatedAllocation.cs
@@ -41,7 +41,7 @@ namespace VMASharp {
             pData = default;
 
             IntPtr tmp;
-            var res = VkApi.MapMemory(Allocator.Device, memory, 0, Vk.WholeSize, 0, (void**)&tmp);
+            var res = VkApi.MapMemory(Allocator.Device, memory, 0, Vk.WholeSize, MemoryMapFlags.None, (void**)&tmp);
 
             if (res == Result.Success) {
                 mappedData = tmp;

--- a/VMASharp/VMASharp.csproj
+++ b/VMASharp/VMASharp.csproj
@@ -19,9 +19,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Silk.NET.Vulkan" Version="2.17.1"/>
-        <PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.17.1"/>
-        <PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.17.1"/>
+        <PackageReference Include="Silk.NET.Vulkan" Version="2.22.0" />
+        <PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.22.0" />
+        <PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.22.0" />
     </ItemGroup>
 
 </Project>

--- a/VMASharp/VulkanMemoryAllocator.cs
+++ b/VMASharp/VulkanMemoryAllocator.cs
@@ -489,8 +489,8 @@ namespace VMASharp {
             VkApi.GetBufferMemoryRequirements2(Device, &req, &memReq2);
 
             memReq = memReq2.MemoryRequirements;
-            requiresDedicatedAllocation = dedicatedRequirements.RequiresDedicatedAllocation != 0;
-            prefersDedicatedAllocation = dedicatedRequirements.PrefersDedicatedAllocation != 0;
+            requiresDedicatedAllocation = dedicatedRequirements.RequiresDedicatedAllocation;
+            prefersDedicatedAllocation = dedicatedRequirements.PrefersDedicatedAllocation;
         }
 
         internal void GetImageMemoryRequirements(Image image, out MemoryRequirements memReq, out bool requiresDedicatedAllocation, out bool prefersDedicatedAllocation) {
@@ -511,8 +511,8 @@ namespace VMASharp {
             VkApi.GetImageMemoryRequirements2(Device, &req, &memReq2);
 
             memReq = memReq2.MemoryRequirements;
-            requiresDedicatedAllocation = dedicatedRequirements.RequiresDedicatedAllocation != 0;
-            prefersDedicatedAllocation = dedicatedRequirements.PrefersDedicatedAllocation != 0;
+            requiresDedicatedAllocation = dedicatedRequirements.RequiresDedicatedAllocation;
+            prefersDedicatedAllocation = dedicatedRequirements.PrefersDedicatedAllocation;
         }
 
         internal Allocation AllocateMemory(in MemoryRequirements memReq, in DedicatedAllocationInfo dedicatedInfo,
@@ -978,7 +978,7 @@ namespace VMASharp {
 
             IntPtr mappedData = default;
             if (map) {
-                res = VkApi.MapMemory(Device, memory, 0, Vk.WholeSize, 0, (void**)&mappedData);
+                res = VkApi.MapMemory(Device, memory, 0, Vk.WholeSize, MemoryMapFlags.None, (void**)&mappedData);
 
                 if (res < 0) {
                     FreeVulkanMemory(memTypeIndex, size, memory);

--- a/VMASharp/VulkanMemoryBlock.cs
+++ b/VMASharp/VulkanMemoryBlock.cs
@@ -84,7 +84,7 @@ namespace VMASharp {
                 }
 
                 IntPtr pData;
-                var res = VkApi.MapMemory(Allocator.Device, DeviceMemory, 0, Vk.WholeSize, 0, (void**)&pData);
+                var res = VkApi.MapMemory(Allocator.Device, DeviceMemory, 0, Vk.WholeSize, MemoryMapFlags.None, (void**)&pData);
 
                 if (res != Result.Success) {
                     throw new MapMemoryException(res);

--- a/VulkanCube/VulkanCube.csproj
+++ b/VulkanCube/VulkanCube.csproj
@@ -15,11 +15,11 @@
 
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-        <PackageReference Include="Silk.NET.GLFW" Version="2.17.1"/>
-        <PackageReference Include="Silk.NET.Vulkan" Version="2.17.1"/>
-        <PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.17.1"/>
-        <PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.17.1"/>
-        <PackageReference Include="Silk.NET.Windowing" Version="2.17.1"/>
+        <PackageReference Include="Silk.NET.GLFW" Version="2.22.0" />
+        <PackageReference Include="Silk.NET.Vulkan" Version="2.22.0" />
+        <PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.22.0" />
+        <PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.22.0" />
+        <PackageReference Include="Silk.NET.Windowing" Version="2.22.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The MapMemory function takes in an enum instead of an integer in newer Silk.NET versions. Which makes the build fail when used in a project with a newer Silk.NET version.